### PR TITLE
input: add fflush

### DIFF
--- a/input.c
+++ b/input.c
@@ -605,6 +605,7 @@ void input_get(struct input *input, bool *quit)
         printf("\x1b[%uH", V->rows); /* move to last line */
         view_text(V);
         printf(":");
+        fflush(stdout);
         input_cmd(input, quit);
         view_dirty_from(V, 0);
         view_visual(V);
@@ -614,6 +615,7 @@ void input_get(struct input *input, bool *quit)
         printf("\x1b[%uH", V->rows); /* move to last line */
         view_text(V);
         printf("/");
+        fflush(stdout);
         input_search(input);
         view_dirty_from(V, 0);
         view_visual(V);


### PR DESCRIPTION
The problem is that on some systems the printf does not flush and the output gets corrupted. I confirm this on musl system. However this is only the begining of the rotten can, as for example scrolling does not work correctly in tty, and I am forced to use ^l to redraw the screen every time, I can make it do that automatically, but it will be suboptimal solution, and cause high cpu spikes.